### PR TITLE
fix crash due to empty text before a softbreak

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -21,6 +21,7 @@ function process_inlines (tokens) {
 
     for (let j = i - 1; j >= 0; j--) {
       if (tokens[j].type !== 'text') continue
+      if (tokens[j].content.length === 0) break
 
       const c1 = tokens[j].content.charCodeAt(tokens[j].content.length - 2)
       const c2 = tokens[j].content.charCodeAt(tokens[j].content.length - 1)
@@ -31,6 +32,7 @@ function process_inlines (tokens) {
 
     for (let j = i + 1; j < tokens.length; j++) {
       if (tokens[j].type !== 'text') continue
+      if (tokens[j].content.length === 0) break
 
       const c1 = tokens[j].content.charCodeAt(0)
       const c2 = tokens[j].content.charCodeAt(1)

--- a/test/fixtures/cjk_breaks.txt
+++ b/test/fixtures/cjk_breaks.txt
@@ -79,3 +79,12 @@ text
 <p><img src="image.png" alt="img">
 text</p>
 .
+
+Should process linebreaks after strong correctly
+.
+**foo**
+bar
+.
+<p><strong>foo</strong>
+bar</p>
+.


### PR DESCRIPTION
Exception is thrown when a softbreak token is after strong token
This script:
```js
var md = require('markdown-it')();
var cjk_breaks = require('markdown-it-cjk-breaks');

md.use(cjk_breaks);

md.render(`
**foo**
bar
`);
```
Throws an exception:
```
TypeError: Expected a code point, got `undefined`.
```

The empty text is generated by `markdown-it` when a `strong` token followed by a `softbreak` token.
<img width="1189" alt="image" src="https://github.com/markdown-it/markdown-it-cjk-breaks/assets/4208726/d2cde4e5-300d-4be9-8c10-0606585a0155">
